### PR TITLE
Make pdfpages+bidi work again on XeTeX after big pdfpages refactor.

### DIFF
--- a/bidi.dtx
+++ b/bidi.dtx
@@ -21146,53 +21146,11 @@ bidi implementation of tufte title]
 % \section{File \texttt{pdfpages-xetex-bidi.def}}
 %    \begin{macrocode}
 \ProvidesFile{pdfpages-xetex-bidi.def}[2010/07/25 v0.1 bidi adaptations for pdfpages package for XeTeX engine]
-\renewcommand*{\includepdf}[2][]{%
-  \begingroup
-  \@RTLfalse
-  \let\AM@threadname\relax
-  \AM@split@options{pdfpages}{#1}%
-  \edef\AM@temp{{pdfpages}{\the\@temptokena}}%
-  \expandafter\setkeys\AM@temp
-  \ifthenelse{\boolean{AM@pkg@draft} \and \boolean{AM@survey}}{%
-    \let\AM@currentdocname\relax
-    \renewcommand\includegraphics[2][]{Survey in draft-mode}%
-    \def\AM@pagecount{0}%
-  }{%
-    \AM@findfile{#2}%
-    \if\AM@threadname\relax
-      \def\AM@threadname{\AM@currentdocname}%
-    \fi
-  }%
-  \ifAM@survey
-    \def\AM@pagestemp{}%
-    \@tempcnta=0
-    \def\foo{%
-      \@ifundefined{r@\AM@xrprefix pdfpages@page\the\@tempcnta}%
-         {\let\foo\relax}
-         {\expandafter\ifx\expandafter\\\AM@pagestemp\\
-             \edef\AM@pagestemp{%
-                \AM@pageref{\AM@xrprefix pdfpages@page\the\@tempcnta}}%
-          \else
-            \edef\AM@pagestemp{\AM@pagestemp,%
-               \AM@pageref{\AM@xrprefix pdfpages@page\the\@tempcnta}}%
-          \fi
-          \advance\@tempcnta 1\relax
-         }%
-      \foo
-    }%
-    \foo
-    \expandafter\ifx\expandafter\\\AM@pagestemp\\
-      \def\AM@pagestemp{1}%
-    \fi
-  \fi
-  \ifAM@output
-    \expandafter\AM@readlist\expandafter{\AM@pagestemp}%
-    \AM@output{#1}%
-  \fi
-  \AM@CheckAtEnd
-  \endgroup
-  \AM@ClearShipoutPicture
-}
+\RequirePackage{etoolbox}
+\expandafter\patchcmd\csname\string\includepdf\endcsname
+  {\begingroup}{\begingroup\@RTLfalse}{%
+  \PackageInfo{pdfpages-xetex-bidi}{Patching command includepdf}}{%
+  \PackageError{pdfpages-xetex-bidi}{Failed patching command includepdf}{}}
 %    \end{macrocode}
 % \iffalse
 %</pdfpages-xetex-bidi.def>


### PR DESCRIPTION
The refactor was done in https://github.com/AndreasMatthias/pdfpages/commit/47d9663ccc1d80b7f670aa1436b06aa79243f1bb The fix here is the workaround from https://github.com/AndreasMatthias/pdfpages/issues/12#issuecomment-2892144364

AndreasMatthias noted in xepersian/bidi#11 that he's not sure whether we need to patch \includepdf at all.

Tested by including this fix in my own document in https://github.com/kbloom/sheetmusic/commit/61e933f6f81db4f40e010c7787a2e241952d16a2

Resolves: xepersian/bidi#11, AndreasMatthias/pdfpages#12